### PR TITLE
Make Mail Queueable by default

### DIFF
--- a/src/Drivers/MailDriver.php
+++ b/src/Drivers/MailDriver.php
@@ -21,7 +21,7 @@ class MailDriver extends Driver implements DriverInterface
         $subject = $message->getTitle();
         $body = $message->getBody();
 
-        Mail::send($view, [
+        Mail::queue($view, [
             'body' => $body,
             'subject' => $subject,
         ], function ($mail) use ($subject, $addresses) {


### PR DESCRIPTION
Hi, I made Mail Queueable by default if application configured to use queues.
Because, it's less overhead.
It's Sync by default. Thanks