### PR TITLE
PATCH - Only mailables may be queued - Laravel 5.3+

### DIFF
--- a/src/Drivers/MailDriver.php
+++ b/src/Drivers/MailDriver.php
@@ -4,6 +4,7 @@ namespace FlyingLuscas\BugNotifier\Drivers;
 
 use Illuminate\Support\Facades\Mail;
 use FlyingLuscas\BugNotifier\Message;
+use FlyingLuscas\BugNotifier\Mail\BugMail;
 
 class MailDriver extends Driver implements DriverInterface
 {
@@ -21,12 +22,8 @@ class MailDriver extends Driver implements DriverInterface
         $subject = $message->getTitle();
         $body = $message->getBody();
 
-        Mail::send($view, [
-            'body' => $body,
-            'subject' => $subject,
-        ], function ($mail) use ($subject, $addresses) {
-            $mail->subject($subject)->to($addresses);
-        });
+        Mail::to($addresses)
+            ->queue(new BugMail($view, $subject, $body));
     }
 
     /**

--- a/src/Mail/BugMail.php
+++ b/src/Mail/BugMail.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FlyingLuscas\BugNotifier\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class BugMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public $view;
+    public $subject;
+    public $body;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param Illuminate\View\View $view
+     * @param string $subject
+     * @param string $body
+     *
+     * @return void
+     */
+    public function __construct($view, $subject, $body)
+    {
+        $this->view = $view;
+        $this->subject = $subject;
+        $this->body = $body;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view($this->view)
+            ->subject($this->subject);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide a patch to support Laravel 5.3+

## Motivation and context

Why is this change required? What problem does it solve?

It does fail to send error messages in Laravel 5.4.36+ with error thrown:

```
InvalidArgumentException
Only mailables may be queued.
```
After I dig enough mailables are support from Laravel 5.3+ 

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [x] My code follows the code style of this project.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
